### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,10 @@ You can link it simply by running `react-native link`.
 ## Usage
 
 ```javascript
-import React, {
+'use strict'
+import React, { Component } from 'react';
+import {
   AppRegistry,
-  Component,
 } from 'react-native';
 import BarcodeScanner from 'react-native-barcodescanner';
 


### PR DESCRIPTION
Current version of react-native uses slightly different syntax for importing components.
README.md instructions throws errors that are fixed by the above refactor.

```
$ react-native -v
react-native-cli: 1.0.0
react-native: 0.31.0
```
