### PR TITLE
ignore Examples/BarcodeScanner/android/app/build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ gen/
 
 # Gradle files
 .gradle/
-build/
+**/build/
 
 # Local configuration file (sdk path, etc)
 local.properties


### PR DESCRIPTION
Current npm package is 12MB because it includes build folder.
This PR makes deep build folders to be excluded